### PR TITLE
Fix Icamparable bug for sequence.cs

### DIFF
--- a/StopGuessing/DataStructures/Sequence.cs
+++ b/StopGuessing/DataStructures/Sequence.cs
@@ -29,7 +29,7 @@ namespace StopGuessing.DataStructures
     /// <typeparam name="T">The type of the item to keep a sequence of.</typeparam>
     [DataContract]
     [JsonConverter(typeof(SequenceConverter))]
-    public class Sequence<T> : ICollection<T>, IEquatable<Sequence<T>>//, IEnumerable<T> , IList<T>
+    public class Sequence<T> : ICollection<T>, IEquatable<Sequence<T>>, IComparable<T> //, IEnumerable<T> , IList<T>
     {
         [IgnoreDataMember]
         protected int CurrentItemIndex;
@@ -313,7 +313,8 @@ namespace StopGuessing.DataStructures
             {
                 for (int i = 0; i < Count; i++)
                 {
-                    if (Comparer<T>.Default.Compare(item, this[i]) == 0)
+                    if (EqualityComparer<T>.Default.Equals(item, this[i]))
+           
                     {
                         RemoveAt(i);
                         return true;
@@ -369,6 +370,10 @@ namespace StopGuessing.DataStructures
             return GetSubsequence().GetHashCode();
         }
 
+        public int CompareTo(T other)
+        {
+            throw new NotImplementedException();
+        }
 
         public class SequenceEnumerator : IEnumerator<T>
         {


### PR DESCRIPTION
The compareto function is just a place holder in case we want to implement our own compare function.